### PR TITLE
Move docs to PlutoStaticHTML 4.0

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,3 +5,4 @@ PlutoStaticHTML = "359b1769-a58e-495b-9770-312e911026ad"
 
 [compat]
 Documenter = "0.27"
+PlutoStaticHTML = "4"

--- a/docs/build.jl
+++ b/docs/build.jl
@@ -9,7 +9,7 @@ function build()
     use_distributed = false
     output_format = documenter_output
     bopts = BuildOptions(NOTEBOOKS_DIR; use_distributed, output_format)
-    parallel_build(bopts)
+    build_notebooks(bopts)
     return nothing
 end
 


### PR DESCRIPTION
People told me that the name `parallel_build` was unclear since the method can also be used for sequential build, so I released a breaking change to change the name to `build_notebooks`.